### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,4 +1,6 @@
 name: docs
+permissions:
+  contents: read
 
 on:
   push:

--- a/.github/workflows/web-interface-ci.yml
+++ b/.github/workflows/web-interface-ci.yml
@@ -1,5 +1,8 @@
 name: Web Interface CI
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     paths:


### PR DESCRIPTION
Potential fix for [https://github.com/BabaSanfour/Coord2Region/security/code-scanning/6](https://github.com/BabaSanfour/Coord2Region/security/code-scanning/6)

In general, the problem is fixed by explicitly defining a `permissions` block that restricts the `GITHUB_TOKEN` to the least privileges needed. For a pure CI workflow that only checks out code, builds, and tests, `contents: read` is typically sufficient. Defining this at the workflow root applies to all jobs that don’t override it.

For this specific workflow, the single best fix with no behavior change is to add a root-level `permissions` section immediately after the `name` (or before `jobs`) specifying `contents: read`. None of the steps here perform any writes via the GitHub API (no tag pushes, issue or PR updates, etc.), so read-only access to repository contents is enough for `actions/checkout` and for accessing artifacts if needed. No new imports or external dependencies are required; this is a YAML-only change in `.github/workflows/web-interface-ci.yml`.

Concretely, in `.github/workflows/web-interface-ci.yml`, add:

```yaml
permissions:
  contents: read
```

right after line 1 (`name: Web Interface CI`) and before the `on:` block. This will satisfy CodeQL and lock down the `GITHUB_TOKEN` to read-only contents for this workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
