### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,4 +1,6 @@
 name: docs
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/BabaSanfour/Coord2Region/security/code-scanning/5](https://github.com/BabaSanfour/Coord2Region/security/code-scanning/5)

In general, the fix is to explicitly declare a `permissions` block for the workflow or for individual jobs, granting only the minimal scopes required. For this docs workflow, the steps only read the repository code (via `actions/checkout`) and then run local build/linkcheck commands. They do not push commits, create releases, or modify issues/PRs, so `contents: read` is sufficient.

The best minimal fix without changing functionality is to add a top-level `permissions` block (applied to all jobs) directly under the `name: docs` line, setting `contents: read`. No additional permissions appear necessary based on the provided snippet. This also matches the “minimal starting point” suggested by CodeQL. No imports or external dependencies are required; the change is purely within `.github/workflows/docs.yml`.

Concretely:
- Edit `.github/workflows/docs.yml`.
- Insert:
  ```yaml
  permissions:
    contents: read
  ```
  after line 1 (`name: docs`) and before the `on:` block, preserving indentation and structure.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
