### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   lint:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6


### PR DESCRIPTION
Potential fix for [https://github.com/BabaSanfour/Coord2Region/security/code-scanning/4](https://github.com/BabaSanfour/Coord2Region/security/code-scanning/4)

To fix the problem, we should explicitly restrict the `GITHUB_TOKEN` permissions for this workflow/job to the minimum needed. This is typically `contents: read` for a linting workflow that only checks code and does not write to the repository or manage issues/PRs.

The best fix without changing existing functionality is to add a `permissions` block at the job level for `lint` (just under `runs-on: ubuntu-latest`), setting `contents: read`. This ensures the job can still check out the code (which requires `contents: read`) while preventing unnecessary write permissions or access to other scopes. No imports or additional methods are needed since this is a YAML workflow file.

Concretely:
- Edit `.github/workflows/lint.yml`.
- Under `jobs.lint.runs-on`, add:

```yaml
    permissions:
      contents: read
```

No other changes are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
